### PR TITLE
debug errors, minor package tidy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 /test/fixtures/*/build/
+npm-debug.log

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ var Joi = require('joi')
 var less = require('less')
 var multimatch = require('multimatch')
 var path = require('path')
+var debug = require('debug')('metalsmith-less')
 
 var MAP_INPUT_KEY = 'input'
 var MAP_RE = /less/g
@@ -59,6 +60,10 @@ function plugin(options) {
                                 contents: new Buffer(JSON.stringify(map)),
                             }
                         }
+                    })
+                    .catch(function (error) {
+                      debug('error', error)
+                      throw error
                     })
             })
             .nodeify(done)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "devDependencies": {
     "assert-dir-equal": "^1.0.1",
-    "crispy": "^3.1.2",
+    "crispy": "^3.2.0",
+    "jshint": "^2.9.4",
     "metalsmith": "^1.3.0",
     "mocha": "^2.2.1"
   }


### PR DESCRIPTION
This patch will change error reporting in metalsmith from `Unrecognized input` to something like:

```javascript
metalsmith-less error +0ms { [Error: Unrecognised input]
  type: 'Parse',
  filename: 'src/styles/zerif.less',
  index: 3880,
  line: 237,
  callLine: NaN,
  callExtract: undefined,
  column: 0,
  extract: 
   [ '',
     '=========================================',
     ' **   SECTION STYLES                 -----' ],
  message: 'Unrecognised input',
  stack: undefined }
```

Additionally, I couldn't get tests to run, I think the crispy dependency is missing from package.json, and the current crispy version expects other dependencies, and I couldn't be bothered figuring out how to get it to work.