### PR TITLE
Adding ability to remove the source file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ new Metalsmith(__dirname)
 
     The [pattern](https://github.com/sindresorhus/multimatch) to filter source files. Default `**/*.less`.
 
+- **`removeSource`** `Boolean`
+
+    When `true`, the source files are removed and will not appear in the `build/` directory.  The default is `false`, which will keep a copy of your `*.less` files around.
+
 - **`render`** `Object`
 
     The options passed to [`less.render(String[, Object])`](http://lesscss.org/usage/#programmatic-usage). Unfortunately, this method is *undocumented*. See https://github.com/less/less-docs/issues/212 for more information. Default `undefined`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ var OPTIONS_SCHEMA = Joi.object().keys({
         Joi.string(),
         Joi.array().items(Joi.string()),
     ]).default('**/*.less'),
+    removeSource: Joi.boolean().default(false),
     render: Joi.object(),
     useDynamicSourceMap: Joi.boolean().default(false),
 })
@@ -23,6 +24,7 @@ function plugin(options) {
     if (validation.error) throw validation.error
     var useDynamicSourceMap = validation.value.useDynamicSourceMap
     var renderOptions = validation.value.render
+    var removeSource = validation.value.removeSource
     return function (files, metalsmith, done) {
         return BPromise
             .filter(Object.keys(files), function (_path) {
@@ -58,6 +60,9 @@ function plugin(options) {
                             files[mapDestination] = {
                                 contents: new Buffer(JSON.stringify(map)),
                             }
+                        }
+                        if (removeSource) {
+                            delete files[_path]
                         }
                     })
             })

--- a/test/fixtures/preserve-source/expected/index.css
+++ b/test/fixtures/preserve-source/expected/index.css
@@ -1,0 +1,3 @@
+.b {
+  font-weight: bold;
+}

--- a/test/fixtures/preserve-source/expected/index.less
+++ b/test/fixtures/preserve-source/expected/index.less
@@ -1,0 +1,1 @@
+.b { font-weight: bold }

--- a/test/fixtures/preserve-source/src/index.less
+++ b/test/fixtures/preserve-source/src/index.less
@@ -1,0 +1,1 @@
+.b { font-weight: bold }

--- a/test/fixtures/remove-source/expected/index.css
+++ b/test/fixtures/remove-source/expected/index.css
@@ -1,0 +1,3 @@
+.b {
+  font-weight: bold;
+}

--- a/test/fixtures/remove-source/src/index.less
+++ b/test/fixtures/remove-source/src/index.less
@@ -1,0 +1,1 @@
+.b { font-weight: bold }

--- a/test/index.js
+++ b/test/index.js
@@ -53,4 +53,26 @@ describe('the plugin', function () {
 
     })
 
+    it('preserves source files by default', function (done) {
+        (new Metalsmith('test/fixtures/preserve-source'))
+            .use(less())
+            .build(function (err) {
+                if (err) return done(err)
+                assertDir('test/fixtures/preserve-source/expected', 'test/fixtures/preserve-source/build')
+                return done(null)
+            })
+    })
+
+    it('removes source files', function (done) {
+        (new Metalsmith('test/fixtures/remove-source'))
+            .use(less({
+                removeSource: true,
+            }))
+            .build(function (err) {
+                if (err) return done(err)
+                assertDir('test/fixtures/remove-source/expected', 'test/fixtures/remove-source/build')
+                return done(null)
+            })
+    })
+
 })


### PR DESCRIPTION
When similar plugins convert the data, they remove the source.  For instance, the markdown plugin will convert `*.md` into `*.html` and also remove `*.md` so it never appears in the build directory.

This patch preserves the original behavior and adds an option that removes the source `*.less` files if desired.

What was needed before this change:

    .use(less())
    .use(moveRemove({
        remove: [ ".*\\.less$" ]
    }))

With this commit added, you only need to do this:

    .use(less({
        removeSource: true
    }))